### PR TITLE
Changes to SqlMapper::&get fix method sig mismatch differences

### DIFF
--- a/src/sqlmapper.php
+++ b/src/sqlmapper.php
@@ -45,7 +45,7 @@ class SqlMapper extends \DB\Cortex
   /**
    *  @see \DB\SQL\Mapper::__get($key)
    */
-  public function __get($key)
+  public function &__get($key)
   {
     if ($key === "properties")
       return $this->properties;


### PR DESCRIPTION
Hi @hanspolo It looks like in FF 3.5.0 the \Magic::__get() has been changed to a method sig of:

function &__get($key) 

This was causing the burgers SqlMapper class to throw an error about an invalid method signature.

This just updates the SqlMapper __get method sig to match the \Magic method sig.  It doesn't seem to have introduced any other errors.

Eric.