### PR TITLE
Return user from user::checkLogin

### DIFF
--- a/src/user.php
+++ b/src/user.php
@@ -74,7 +74,7 @@ class DbUser extends SqlMapper
    *  @param String $email
    *  @param String $password
    *
-   *  @return Boolean
+   *  @return Mixed
    */
   public function checkLogin($login, $password)
   {
@@ -87,7 +87,14 @@ class DbUser extends SqlMapper
     if ($clone->dry())
       return false;
 
-    return Bcrypt::instance()->verify($password, $clone->password);
+    if (Bcrypt::instance()->verify($password, $clone->password))
+    {
+      return $clone;
+    }
+    else
+    {
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
Currently the checkLogin method only returns a boolean to indicate success or failure.  If you then want to use the user for anything else, maybe to put into the session, a second database lookup is required to get the user.

With this PR checkLogin for a DBUser will also return the user record.  False is returned on failure.  The ldap version of User remains unchanged.

This PR shouldn't break anything as it is still returning a true-thy value, just substituting the user record for a boolean.

This PR requires PR #3 to work with the 3.5.0 version of F3 framework.

Eric.